### PR TITLE
Fix hardcoded string in episode listing template (issue #53)

### DIFF
--- a/templates/partials/podcast_episodes_list.html.twig
+++ b/templates/partials/podcast_episodes_list.html.twig
@@ -31,7 +31,7 @@
                     </h3>
                 </a>
                 <p class="episode-date">
-                    {{ (datestamp)|nicetime(false) }}{% if e.header.podcast.audio.meta %} | <a href ="{{ e.header.podcast.audio.meta.guid }}">Download Audio</a>{% endif %}
+                    {{ (datestamp)|nicetime(false) }}{% if e.header.podcast.audio.meta %} | <a href ="{{ e.header.podcast.audio.meta.guid }}"> {{ 'PLUGIN_PODCAST.EPISODE_CONTENT.DOWNLOAD'|t|e }}</a>{% endif %}
                 </p>
                 <p class="episode-description">
                     {% if e.summary %}


### PR DESCRIPTION
Fix hardcoded string to use translation system.
(Issue #53)