### PR TITLE
Add itunes summary

### DIFF
--- a/blueprints/podcast-channel.yaml
+++ b/blueprints/podcast-channel.yaml
@@ -43,6 +43,10 @@ form:
               type: text
               label: PLUGIN_PODCAST.ADMIN.CHANNEL.CHANNEL_META.PODCAST_SUBTITLE_LABEL
               help: PLUGIN_PODCAST.ADMIN.CHANNEL.CHANNEL_META.PODCAST_SUBTITLE_HELPTEXT
+            header.podcast.itunes.summary:
+              type: textarea
+              label: PLUGIN_PODCAST.ADMIN.CHANNEL.CHANNEL_META.PODCAST_SUMMARY_LABEL
+              help: PLUGIN_PODCAST.ADMIN.CHANNEL.CHANNEL_META.PODCAST_SUMMARY_HELPTEXT
             header.podcast.description:
               type: markdown
               label: PLUGIN_PODCAST.ADMIN.CHANNEL.CHANNEL_META.PODCAST_DESCRIPTION_LABEL

--- a/languages.yaml
+++ b/languages.yaml
@@ -29,6 +29,8 @@ en:
           PODCAST_TITLE_HELPTEXT: Used in the RSS feed.
           PODCAST_SUBTITLE_LABEL: iTunes Subtitle
           PODCAST_SUBTITLE_HELPTEXT: 'Example: "A show about everything..."'
+          PODCAST_SUMMARY_LABEL: iTunes Summary
+          PODCAST_SUMMARY_HELPTEXT: iTunes summary (if empty, will fallback to podcast page content, then channel description)
           PODCAST_DESCRIPTION_LABEL: Channel Description
           PODCAST_LINK_LABEL: Channel URL
           PODCAST_LINK_HELPTEXT: Used in the RSS feed.

--- a/templates/feed.rss.twig
+++ b/templates/feed.rss.twig
@@ -14,7 +14,7 @@
 <copyright>{{ channel.header.podcast.copyright }}</copyright>
 <itunes:subtitle>{{ channel.header.podcast.itunes.subtitle }}</itunes:subtitle>
 <itunes:author>{{ channel.header.podcast.itunes.author }}</itunes:author>
-<itunes:summary>{{ (channel.content ? channel.content : channel.header.podcast.description)|striptags }}</itunes:summary>
+<itunes:summary>{{ channel.header.podcast.itunes.summary ?: (channel.content ? channel.content : channel.header.podcast.description)|striptags }}</itunes:summary>
 <description>{{ channel.header.podcast.description|striptags }}</description>
 <itunes:owner>
     <itunes:name>{{ channel.header.podcast.itunes.owner.name }}</itunes:name>


### PR DESCRIPTION
Hello,

This is a suggestion to add the possibility to specifically define iTunes summary.

This is a way to avoid using the podcast page content when it is used for something else.

If not set will fallback to the usual content/description logic. (This is an optional override.)

Kind regards.