### PR TITLE
Better language support (grammar)

### DIFF
--- a/languages.yaml
+++ b/languages.yaml
@@ -12,8 +12,11 @@ en:
       SERIES: Series
     SERIES_CONTENT:
       HEADER: Series Description
+      LATEST_SERIES: Latest series
     EPISODE_CONTENT:
       HEADER: Episode Content
+      LATEST_EPISODES: Latest episodes
+      LATEST_EPISODES_IN: Latest episodes in
       DOWNLOAD: Download Audio
       WARNING: Your browser does not support the audio tag.
       EMPTY: No content available.
@@ -92,8 +95,11 @@ fr:
       SERIES: Séries
     SERIES_CONTENT:
       HEADER: Description de la série
+      LATEST_SERIES: Dernières séries
     EPISODE_CONTENT:
       HEADER: Contenu de l'épisode
+      LATEST_EPISODES: Derniers épisodes
+      LATEST_EPISODES_IN: Derniers épisodes dans
       DOWNLOAD: Télécharger le fichier audio
       WARNING: Votre navigateur ne prend pas en charge la balise audio.
       EMPTY: Aucun contenu disponible.
@@ -111,8 +117,11 @@ pt:
       SERIES: Séries
     SERIES_CONTENT:
       HEADER: Descrição da série
+      LATEST_SERIES: Últimas séries
     EPISODE_CONTENT:
       HEADER: Conteúdo do episódio
+      LATEST_EPISODES: Últimos episódios
+      LATEST_EPISODES_IN: Últimos episódios em
       DOWNLOAD: Baixar áudio
       WARNING: Seu navegador não suporta a etiqueta de áudio.
       EMPTY: Nenhum conteúdo disponível.

--- a/templates/partials/podcast_episodes_list.html.twig
+++ b/templates/partials/podcast_episodes_list.html.twig
@@ -1,6 +1,6 @@
 <div class = "podcast-full-list">
     {% if (episodes|length > 0)%}
-    <h2>{{ 'PLUGIN_PODCAST.WORDS.LATEST'|t|e }} {{ 'PLUGIN_PODCAST.WORDS.EPISODE'|t|e|pluralize }}</h2>
+    <h2>{{ 'PLUGIN_PODCAST.EPISODE_CONTENT.LATEST_EPISODES'|t|e }}</h2>
 
     <div class="channel-links">
         <a href="{{ base_url }}{{ page.route }}.rss">RSS <i class="fa fa-rss" aria-hidden="true"></i> | {{ page.title }}</a>

--- a/templates/partials/podcast_episodes_mini_list.html.twig
+++ b/templates/partials/podcast_episodes_mini_list.html.twig
@@ -12,7 +12,7 @@
 {% endif %}
 
 <div class="episodes-mini-list">
-    <h3>{{ 'PLUGIN_PODCAST.WORDS.LATEST'|t|e }} {{ page.parent.title }} {{ 'PLUGIN_PODCAST.WORDS.EPISODE'|t|e|pluralize }}</h3>
+    <h3>{{ 'PLUGIN_PODCAST.EPISODE_CONTENT.LATEST_EPISODES_IN'|t|e }} {{ page.parent.title }}</h3>
     <ul>
         {% for e in episodes %}
             <li><a href="{{ e.url() }}">{{ e.title }}</a></li>

--- a/templates/partials/podcast_series_list.html.twig
+++ b/templates/partials/podcast_series_list.html.twig
@@ -1,6 +1,6 @@
 <div class = "podcast-full-list">
     {% if (series|length > 0)%}
-    <h2>{{ 'PLUGIN_PODCAST.WORDS.LATEST'|t|e }} {{ 'PLUGIN_PODCAST.WORDS.SERIES'|t|e }}</h2>
+    <h2>{{ 'PLUGIN_PODCAST.SERIES_CONTENT.LATEST_SERIES'|t|e }}</h2>
     
     <div class="channel-links">
         All Series

--- a/templates/partials/podcast_series_mini_list.html.twig
+++ b/templates/partials/podcast_series_mini_list.html.twig
@@ -17,7 +17,7 @@
 {% endif %}
 
 <div class="episodes-mini-list">
-    <h3>{{ 'PLUGIN_PODCAST.WORDS.LATEST'|t|e }} {{ 'PLUGIN_PODCAST.WORDS.SERIES'|t|pluralize }}</h3>
+    <h3>{{ 'PLUGIN_PODCAST.SERIES_CONTENT.LATEST_SERIES'|t }}</h3>
     <ul>
         {% for s in series %}
             <li><a href="{{ s.url() }}">{{ s.title }}</a></li>


### PR DESCRIPTION
Hello,

It is not possible to use separate words in many languages because of grammar rules. Small sentences are needed.

This suggestion makes the little adaptations required to have proper translation in other languages.

Kind regards.