### PR TITLE
Downloads Pro and Podtrac support

### DIFF
--- a/blueprints/podcast-channel.yaml
+++ b/blueprints/podcast-channel.yaml
@@ -61,6 +61,17 @@ form:
               type: text
               label: PLUGIN_PODCAST.ADMIN.CHANNEL.CHANNEL_META.PODCAST_COPYRIGHT_LABEL
               default: 2021 Example.com
+            header.podcast.podtrac:
+              type: toggle
+              toggleable: true
+              label: PLUGIN_PODCAST.ADMIN.CHANNEL.CHANNEL_META.PODTRAC
+              help: PLUGIN_PODCAST.ADMIN.CHANNEL.CHANNEL_META.PODTRAC_HELP
+              highlight: 1
+              options:
+                  1: 'Yes'
+                  0: 'No'
+              validate:
+                  type: bool
 
         itunesMetaTab:
           type: tab

--- a/languages.yaml
+++ b/languages.yaml
@@ -35,6 +35,8 @@ en:
           PODCAST_LANG_LABEL: Channel Language
           PODCAST_LANG_HELPTEXT: Used only for the RSS feed.
           PODCAST_COPYRIGHT_LABEL: Copyright
+          PODTRAC: Add Podtrac Prefix
+          PODTRAC_HELP: Add required prefix for Podtrac to work. (See podtrac.com to create an account and register your RSS feed.)
         ITUNES_META:
           TAB_TITLE: iTunes Meta
           TAB_HELPTEXT: Metadata related to the podcast's iTunes section.

--- a/templates/feed.rss.twig
+++ b/templates/feed.rss.twig
@@ -42,8 +42,12 @@
     <enclosure length="{{ episode.header.podcast.audio.meta.enclosure_length }}" type="{{ episode.header.podcast.audio.meta.type }}" url="{{ episode.header.podcast.audio.remote }}"/>
     <guid>{{ episode.header.podcast.audio.remote }}</guid>
     {% else -%}
-    <enclosure length="{{ episode.header.podcast.audio.meta.enclosure_length }}" type="{{ episode.header.podcast.audio.meta.type }}" url="{{ uri.base }}{{ episode.header.podcast.audio.meta.guid }}"/>
-    <guid>{{ uri.base }}{{ episode.header.podcast.audio.meta.guid }}</guid>
+    {# Downloads Pro plugin support: if the same file is available in Downloads Pro, we use this URL. #}
+    {%- set podcast_url = grav.downloads.getPage(episode).getDownloadUrl(episode.header.podcast.audio.local.select) ?: episode.header.podcast.audio.meta.guid %}
+    {# Podtrac support: if enabled, will add the required URL prefix and insert the correct file format (extension). #}
+    {%- set podcast_url = (channel.header.podcast.podtrac ? 'https://dts.podtrac.com/redirect.' ~ episode.header.podcast.audio.meta.guid|split('.')|last ~ '/' ~ uri.host : uri.base) ~ podcast_url -%}
+    <enclosure length="{{ episode.header.podcast.audio.meta.enclosure_length }}" type="{{ episode.header.podcast.audio.meta.type }}" url="{{ podcast_url }}"/>
+    <guid>{{ podcast_url }}</guid>
     {% endif -%}
     <pubDate>{{ episode.header.publish_date ? episode.header.publish_date|date('r') : episode.date|date('r') }}</pubDate>
     <itunes:duration>{{ episode.header.podcast.audio.meta.duration }}</itunes:duration>

--- a/templates/feed.rss.twig
+++ b/templates/feed.rss.twig
@@ -42,10 +42,12 @@
     <enclosure length="{{ episode.header.podcast.audio.meta.enclosure_length }}" type="{{ episode.header.podcast.audio.meta.type }}" url="{{ episode.header.podcast.audio.remote }}"/>
     <guid>{{ episode.header.podcast.audio.remote }}</guid>
     {% else -%}
+    {%- set podcast_ext = episode.header.podcast.audio.meta.guid|split('.')|last %}
     {# Downloads Pro plugin support: if the same file is available in Downloads Pro, we use this URL. #}
-    {%- set podcast_url = grav.downloads.getPage(episode).getDownloadUrl(episode.header.podcast.audio.local.select) ?: episode.header.podcast.audio.meta.guid %}
+    {%- set podcast_url = grav.downloads.getPage(episode).getDownloadUrl(episode.header.podcast.audio.local.select) %}
+    {%- set podcast_url = podcast_url ? podcast_url ~ '.' ~ podcast_ext : episode.header.podcast.audio.meta.guid %}
     {# Podtrac support: if enabled, will add the required URL prefix and insert the correct file format (extension). #}
-    {%- set podcast_url = (channel.header.podcast.podtrac ? 'https://dts.podtrac.com/redirect.' ~ episode.header.podcast.audio.meta.guid|split('.')|last ~ '/' ~ uri.host : uri.base) ~ podcast_url -%}
+    {%- set podcast_url = (channel.header.podcast.podtrac ? 'https://dts.podtrac.com/redirect.' ~ podcast_ext ~ '/' ~ uri.host : uri.base) ~ podcast_url -%}
     <enclosure length="{{ episode.header.podcast.audio.meta.enclosure_length }}" type="{{ episode.header.podcast.audio.meta.type }}" url="{{ podcast_url }}"/>
     <guid>{{ podcast_url }}</guid>
     {% endif -%}

--- a/templates/partials/podcast_episodes_list.html.twig
+++ b/templates/partials/podcast_episodes_list.html.twig
@@ -31,7 +31,8 @@
                     </h3>
                 </a>
                 <p class="episode-date">
-                    {{ (datestamp)|nicetime(false) }}{% if e.header.podcast.audio.meta %} | <a href ="{{ e.header.podcast.audio.meta.guid }}"> {{ 'PLUGIN_PODCAST.EPISODE_CONTENT.DOWNLOAD'|t|e }}</a>{% endif %}
+                    {# If there is a matching file in Downloads Pro, we use it. #}
+                    {{ (datestamp)|nicetime(false) }}{% if e.header.podcast.audio.meta %} | <a href ="{{ grav.downloads.getPage().getDownloadUrl(e.header.podcast.audio.local.select) ?: e.header.podcast.audio.meta.guid }}"> {{ 'PLUGIN_PODCAST.EPISODE_CONTENT.DOWNLOAD'|t|e }}</a>{% endif %}
                 </p>
                 <p class="episode-description">
                     {% if e.summary %}

--- a/templates/podcast-episode.html.twig
+++ b/templates/podcast-episode.html.twig
@@ -28,9 +28,11 @@
 
         <div class="podcast-flex-child podcast-flex-full">
             {% if (header.podcast.audio.meta.guid) %}
+                {# If there is a matching file in Downloads Pro, we use it. #}
+                {%- set podcast_url = grav.downloads.getPage().getDownloadUrl(header.podcast.audio.local.select) ?: header.podcast.audio.meta.guid %}
                 <div class="podcast-episode-audio">
-                    <audio controls="1" alt="{{ episode.title }}"><source src="{{ page.header.podcast.audio.meta.guid }}">{{ 'PLUGIN_PODCAST.EPISODE_CONTENT.WARNING'|t|e }}</audio></br>
-                    <a href ="{{ header.podcast.audio.meta.guid }}">{{ 'PLUGIN_PODCAST.EPISODE_CONTENT.DOWNLOAD'|t|e }}</a> | Published {{ episode_datestamp|nicetime(false) }}
+                    <audio controls="1" alt="{{ episode.title }}"><source src="{{ podcast_url }}">{{ 'PLUGIN_PODCAST.EPISODE_CONTENT.WARNING'|t|e }}</audio></br>
+                    <a href ="{{ podcast_url }}">{{ 'PLUGIN_PODCAST.EPISODE_CONTENT.DOWNLOAD'|t|e }}</a> | Published {{ episode_datestamp|nicetime(false) }}
                 </div>
             {% else %}
                 <div><p>No audio for this episode</p></div>


### PR DESCRIPTION
Hello,

This suggestion adds two features:
1. Support for Downloads Pro Premium Plugin. If a matching download is found in Downloads Pro, it will be used as podcast URL. This works with some application. (Not sure about Apple.) If Downloads Pro is not installed, it will work as usual.
2. Add support for Podtrac podcast analytics. The option can be toggled on or off per channel.

Kind regards.